### PR TITLE
Fixed stream has already been operated upon or closed exception

### DIFF
--- a/src/main/java/com/oneandone/compositejks/CompositeX509KeyManager.java
+++ b/src/main/java/com/oneandone/compositejks/CompositeX509KeyManager.java
@@ -14,10 +14,10 @@ import static java.util.Arrays.stream;
  */
 public class CompositeX509KeyManager implements X509KeyManager {
 
-    private final Stream<X509KeyManager> children;
+    private final X509KeyManager[] children;
 
     public CompositeX509KeyManager(X509KeyManager... children) {
-        this.children = stream(children);
+        this.children = children;
     }
 
     @Override
@@ -41,7 +41,8 @@ public class CompositeX509KeyManager implements X509KeyManager {
     }
 
     private <TOut> TOut getFirstNonNull(Function<X509KeyManager, TOut> map) {
-        return children.map(map)
+        return stream(children)
+                .map(map)
                 .filter(x -> x != null)
                 .findFirst().orElse(null);
     }
@@ -57,7 +58,7 @@ public class CompositeX509KeyManager implements X509KeyManager {
     }
 
     private String[] merge(Function<X509KeyManager, String[]> map) {
-        return children
+        return stream(children)
                 .flatMap(x -> stream(map.apply(x)))
                 .toArray(size -> new String[size]);
     }


### PR DESCRIPTION
Fixes #7 

Fixed by saving the array of optional parameters and by creating a stream when needed. <i>IllegalStateException: stream has already been operated upon or closed</i> was occuring when using secure LDAP connections (ldaps://...).

Tested using code from v1.0 tag. Code from master branch appears to contain syntax errors and does not appear to compile successfully.

